### PR TITLE
[codex] Improve timetable overlap layout and split card styling

### DIFF
--- a/app/src/main/java/com/stupidtree/hitax/data/repository/IcsImportEventMapper.kt
+++ b/app/src/main/java/com/stupidtree/hitax/data/repository/IcsImportEventMapper.kt
@@ -1,0 +1,31 @@
+package com.stupidtree.hitax.data.repository
+
+import com.stupidtree.hitax.data.model.timetable.EventItem
+import net.fortuna.ical4j.model.component.VEvent
+import java.sql.Timestamp
+import java.util.UUID
+
+object IcsImportEventMapper {
+    fun map(event: VEvent, timetableId: String): EventItem? {
+        val startDate = event.startDate?.date ?: return null
+        val endDate = event.endDate?.date ?: return null
+
+        val item = EventItem()
+        item.id = UUID.randomUUID().toString()
+        item.timetableId = timetableId
+        item.name = event.summary?.value ?: "未知课程"
+
+        val locationStr = event.location?.value ?: ""
+        val parts = locationStr.split(" ", limit = 2)
+        item.place = parts.getOrNull(0) ?: ""
+        item.teacher = parts.getOrNull(1) ?: ""
+
+        item.from = Timestamp(startDate.time)
+        item.to = Timestamp(endDate.time)
+        item.fromNumber = 0
+        item.lastNumber = 0
+        item.type = EventItem.TYPE.OTHER
+        item.color = -1
+        return item
+    }
+}

--- a/app/src/main/java/com/stupidtree/hitax/data/repository/TimetableRepository.kt
+++ b/app/src/main/java/com/stupidtree/hitax/data/repository/TimetableRepository.kt
@@ -336,58 +336,9 @@ class TimetableRepository(val application: Application) {
                 var importedCount = 0
                 
                 for (event in events) {
-                    val ei = EventItem()
-                    ei.id = UUID.randomUUID().toString()
-                    ei.timetableId = timetableId
-                    
-                    // 解析事件标题
-                    ei.name = event.summary?.value ?: "未知课程"
-                    
-                    // 解析地点和教师
-                    val locationStr = event.location?.value ?: ""
-                    val parts = locationStr.split(" ", limit = 2)
-                    ei.place = parts.getOrNull(0) ?: ""
-                    ei.teacher = parts.getOrNull(1) ?: ""
-                    
-                    // 解析开始和结束时间
-                    val startDate = event.startDate?.date
-                    val endDate = event.endDate?.date
-                    
-                    if (startDate != null && endDate != null) {
-                        ei.from = java.sql.Timestamp(startDate.time)
-                        ei.to = java.sql.Timestamp(endDate.time)
-                        
-                        // 使用 Calendar 计算节次
-                        val cal = Calendar.getInstance()
-                        cal.time = startDate
-                        val hour = cal.get(Calendar.HOUR_OF_DAY)
-                        val minute = cal.get(Calendar.MINUTE)
-                        
-                        cal.time = endDate
-                        val endHour = cal.get(Calendar.HOUR_OF_DAY)
-                        val endMinute = cal.get(Calendar.MINUTE)
-                        
-                        // 根据时间推断节次（基于默认时间表）
-                        ei.fromNumber = when {
-                            hour < 9 || (hour == 9 && minute < 25) -> 1
-                            hour < 10 || (hour == 10 && minute < 30) -> 3
-                            hour < 12 || (hour == 12 && minute < 15) -> 5
-                            hour < 14 || (hour == 14 && minute < 55) -> 7
-                            hour < 16 || (hour == 16 && minute < 0) -> 9
-                            hour < 17 || (hour == 17 && minute < 45) -> 11
-                            else -> 1
-                        }
-                        
-                        val durationMinutes = (endHour * 60 + endMinute) - (hour * 60 + minute)
-                        ei.lastNumber = (durationMinutes / 45).coerceAtLeast(1)
-                        
-                        ei.type = EventItem.TYPE.OTHER
-                        ei.color = -1
-                        
-                        // 保存到数据库
-                        eventItemDao.insertEventSync(ei)
-                        importedCount++
-                    }
+                    val ei = IcsImportEventMapper.map(event, timetableId) ?: continue
+                    eventItemDao.insertEventSync(ei)
+                    importedCount++
                 }
                 
                 // 同步到云端

--- a/app/src/main/java/com/stupidtree/hitax/ui/main/timetable/views/TimeTableBlockView.kt
+++ b/app/src/main/java/com/stupidtree/hitax/ui/main/timetable/views/TimeTableBlockView.kt
@@ -6,32 +6,29 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.text.TextUtils
 import android.util.TypedValue
-import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.TextView
 import com.stupidtree.hitax.R
 import com.stupidtree.hitax.data.model.timetable.EventItem
 import com.stupidtree.hitax.ui.main.timetable.TimetableStyleSheet
-import kotlin.math.max
-import kotlin.math.min
+import kotlin.math.roundToInt
 
 class TimeTableBlockView constructor(
     context: Context,
-    var block: Any,
-    var styleSheet: TimetableStyleSheet
-) :
-    FrameLayout(context) {
+    private val event: EventItem,
+    var styleSheet: TimetableStyleSheet,
+    private val columnIndex: Int = 0,
+    private val columnCount: Int = 1
+) : FrameLayout(context) {
     lateinit var card: View
     var title: TextView? = null
     var subtitle: TextView? = null
     var icon: ImageView? = null
     var onCardClickListener: OnCardClickListener? = null
     var onCardLongClickListener: OnCardLongClickListener? = null
-    var onDuplicateCardClickListener: OnDuplicateCardClickListener? = null
-    var onDuplicateCardLongClickListener: OnDuplicateCardLongClickListener? = null
 
     interface OnCardClickListener {
         fun onClick(v: View, ei: EventItem)
@@ -41,10 +38,6 @@ class TimeTableBlockView constructor(
         fun onLongClick(v: View, ei: EventItem): Boolean
     }
 
-    interface OnDuplicateCardClickListener {
-        fun onDuplicateClick(v: View, list: List<EventItem>)
-    }
-
     private fun getColor(color: Int): Int {
         val typedValue = TypedValue()
         context.theme.resolveAttribute(color, typedValue, true)
@@ -52,7 +45,6 @@ class TimeTableBlockView constructor(
     }
 
     private fun initEventCard(context: Context) {
-        val ei = block as EventItem
         inflate(context, R.layout.fragment_timetable_class_card, this)
         card = findViewById(R.id.card)
         title = findViewById(R.id.title)
@@ -64,13 +56,13 @@ class TimeTableBlockView constructor(
             card.setBackgroundResource(R.drawable.spec_timetable_card_background)
         }
         if (styleSheet.isColorEnabled) {
-            card.backgroundTintList = ColorStateList.valueOf(ei.color)
+            card.backgroundTintList = ColorStateList.valueOf(event.color)
         } else {
             card.backgroundTintList = ColorStateList.valueOf(getColor(R.attr.colorPrimary))
         }
         when (styleSheet.cardTitleColor) {
             "subject" -> if (styleSheet.isColorEnabled) {
-                title?.setTextColor(ei.color)
+                title?.setTextColor(event.color)
             } else title?.setTextColor(getColor(R.attr.colorPrimary))
             "white" -> title?.setTextColor(Color.WHITE)
             "black" -> title?.setTextColor(Color.BLACK)
@@ -78,7 +70,7 @@ class TimeTableBlockView constructor(
         }
         when (styleSheet.subTitleColor) {
             "subject" -> if (styleSheet.isColorEnabled) {
-                subtitle?.setTextColor(ei.color)
+                subtitle?.setTextColor(event.color)
             } else subtitle?.setTextColor(getColor(R.attr.colorPrimary))
             "white" -> subtitle?.setTextColor(Color.WHITE)
             "black" -> subtitle?.setTextColor(Color.BLACK)
@@ -89,7 +81,7 @@ class TimeTableBlockView constructor(
             icon?.setColorFilter(Color.WHITE)
             when (styleSheet.iconColor) {
                 "subject" -> if (styleSheet.isColorEnabled) {
-                    icon?.setColorFilter(ei.color)
+                    icon?.setColorFilter(event.color)
                 } else icon?.setColorFilter(getColor(R.attr.colorPrimary))
                 "white" -> icon?.setColorFilter(Color.WHITE)
                 "black" -> icon?.setColorFilter(Color.BLACK)
@@ -99,12 +91,12 @@ class TimeTableBlockView constructor(
             icon?.visibility = GONE
         }
 
-        card.setOnClickListener { v -> onCardClickListener?.onClick(v, ei) }
+        card.setOnClickListener { v -> onCardClickListener?.onClick(v, event) }
         card.setOnLongClickListener { v: View ->
-            return@setOnLongClickListener onCardLongClickListener?.onLongClick(v, ei) == true
+            return@setOnLongClickListener onCardLongClickListener?.onLongClick(v, event) == true
         }
-        title?.text = ei.name
-        subtitle?.text = if (TextUtils.isEmpty(ei.place)) "" else ei.place
+        title?.text = event.name
+        subtitle?.text = if (TextUtils.isEmpty(event.place)) "" else event.place
         card.background.mutate().alpha = (255 * (styleSheet.cardOpacity.toFloat() / 100)).toInt()
         if (styleSheet.isBoldText) {
             title?.typeface = Typeface.DEFAULT_BOLD
@@ -113,188 +105,66 @@ class TimeTableBlockView constructor(
         title?.alpha = styleSheet.titleAlpha.toFloat() / 100
         subtitle?.alpha = styleSheet.subtitleAlpha.toFloat() / 100
         title?.gravity = styleSheet.titleGravity
+        applyTextScaleForColumns()
+        applyMarginScaleForColumns()
     }
 
+    private fun applyTextScaleForColumns() {
+        val scale = TimetableCardTextScale.forColumnCount(columnCount)
+        if (scale == 1f) {
+            return
+        }
+        title?.let {
+            it.setTextSize(TypedValue.COMPLEX_UNIT_PX, it.textSize * scale)
+        }
+        subtitle?.let {
+            it.setTextSize(TypedValue.COMPLEX_UNIT_PX, it.textSize * scale)
+        }
+    }
+
+    private fun applyMarginScaleForColumns() {
+        val scale = TimetableCardTextScale.marginScaleForColumnCount(columnCount)
+        if (scale == 1f) {
+            return
+        }
+        scaleMargins(icon, scale)
+        scaleMargins(title, scale)
+        scaleMargins(subtitle, scale)
+    }
+
+    private fun scaleMargins(view: View?, scale: Float) {
+        val params = view?.layoutParams as? ViewGroup.MarginLayoutParams ?: return
+        params.leftMargin = (params.leftMargin * scale).roundToInt()
+        params.topMargin = (params.topMargin * scale).roundToInt()
+        params.rightMargin = (params.rightMargin * scale).roundToInt()
+        params.bottomMargin = (params.bottomMargin * scale).roundToInt()
+        view.layoutParams = params
+    }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        if (block is EventItem) {
+        if (!this::card.isInitialized) {
             initEventCard(context)
-        } else if (block is List<*>) {
-            initDuplicateCard(context)
         }
     }
 
-
-    @Suppress("UNCHECKED_CAST")
-    private fun initDuplicateCard(context: Context) {
-        val list: List<EventItem> = block as List<EventItem>
-        // 创建一个垂直的 LinearLayout 来容纳多个课程块
-        val container = LinearLayout(context)
-        container.orientation = LinearLayout.VERTICAL
-        container.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
-        addView(container)
-        
-        // 为每个冲突的课程创建一个子块
-        val count = list.size
-        for (index in list.indices) {
-            val ei = list[index]
-            val childBlock = createChildEventCard(context, ei, index, count)
-            container.addView(childBlock)
-        }
-        
-        // 为整个容器也设置点击事件（兼容旧的点击方式）
-        container.setOnClickListener { v ->
-            onDuplicateCardClickListener?.onDuplicateClick(v, list)
-        }
-        container.setOnLongClickListener { v ->
-            onDuplicateCardLongClickListener?.onDuplicateLongClick(v, list) == true
-        }
-    }
-    
-    /**
-     * 创建冲突课程中的一个子块
-     */
-    private fun createChildEventCard(context: Context, ei: EventItem, index: Int, total: Int): View {
-        val childView = FrameLayout(context)
-        val layoutParams = LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f)
-        if (index < total - 1) {
-            layoutParams.setMargins(0, 0, 0, 2) // 添加微小间距区分
-        }
-        childView.layoutParams = layoutParams
-        
-        // inflate 单个课程卡片布局（使用LayoutInflater因为布局使用了merge标签）
-        // attachToRoot=true 后布局已自动添加到 childView 中
-        LayoutInflater.from(context).inflate(R.layout.fragment_timetable_class_card, childView, true)
-        val card = childView.findViewById<View>(R.id.card)
-        val title = childView.findViewById<TextView>(R.id.title)
-        val subtitle = childView.findViewById<TextView>(R.id.subtitle)
-        val icon = childView.findViewById<ImageView>(R.id.icon)
-        
-        // 设置样式
-        if (styleSheet.isFadeEnabled) {
-            card.setBackgroundResource(R.drawable.spec_timetable_card_background_fade)
-        } else {
-            card.setBackgroundResource(R.drawable.spec_timetable_card_background)
-        }
-        
-        if (styleSheet.isColorEnabled) {
-            card.backgroundTintList = ColorStateList.valueOf(ei.color)
-        } else {
-            card.backgroundTintList = ColorStateList.valueOf(getColor(R.attr.colorPrimary))
-        }
-        
-        when (styleSheet.cardTitleColor) {
-            "subject" -> if (styleSheet.isColorEnabled) {
-                title?.setTextColor(ei.color)
-            } else title?.setTextColor(getColor(R.attr.colorPrimary))
-            "white" -> title?.setTextColor(Color.WHITE)
-            "black" -> title?.setTextColor(Color.BLACK)
-            "primary" -> title?.setTextColor(getColor(R.attr.colorPrimary))
-        }
-        
-        when (styleSheet.subTitleColor) {
-            "subject" -> if (styleSheet.isColorEnabled) {
-                subtitle?.setTextColor(ei.color)
-            } else subtitle?.setTextColor(getColor(R.attr.colorPrimary))
-            "white" -> subtitle?.setTextColor(Color.WHITE)
-            "black" -> subtitle?.setTextColor(Color.BLACK)
-            "primary" -> subtitle?.setTextColor(getColor(R.attr.colorPrimary))
-        }
-        
-        if (styleSheet.cardIconEnabled) {
-            icon?.visibility = VISIBLE
-            icon?.setColorFilter(Color.WHITE)
-            when (styleSheet.iconColor) {
-                "subject" -> if (styleSheet.isColorEnabled) {
-                    icon?.setColorFilter(ei.color)
-                } else icon?.setColorFilter(getColor(R.attr.colorPrimary))
-                "white" -> icon?.setColorFilter(Color.WHITE)
-                "black" -> icon?.setColorFilter(Color.BLACK)
-                "primary" -> icon?.setColorFilter(getColor(R.attr.colorPrimary))
-            }
-        } else {
-            icon?.visibility = GONE
-        }
-        
-        // 点击事件 - 对于冲突课程中的子卡片，使用 onDuplicateCardClickListener 传递单个课程
-        card.setOnClickListener { v ->
-            // 尝试使用单个课程回调，如果没有设置则使用冲突课程回调
-            if (onCardClickListener != null) {
-                onCardClickListener?.onClick(v, ei)
-            } else {
-                onDuplicateCardClickListener?.onDuplicateClick(v, listOf(ei))
-            }
-        }
-        card.setOnLongClickListener { v: View ->
-            val result = if (onCardLongClickListener != null) {
-                onCardLongClickListener?.onLongClick(v, ei)
-            } else {
-                onDuplicateCardLongClickListener?.onDuplicateLongClick(v, listOf(ei))
-            }
-            return@setOnLongClickListener result == true
-        }
-        
-        title?.text = ei.name
-        subtitle?.text = if (TextUtils.isEmpty(ei.place)) "" else ei.place
-        card.background.mutate().alpha = (255 * (styleSheet.cardOpacity.toFloat() / 100)).toInt()
-        
-        if (styleSheet.isBoldText) {
-            title?.typeface = Typeface.DEFAULT_BOLD
-            subtitle?.typeface = Typeface.DEFAULT_BOLD
-        }
-        title?.alpha = styleSheet.titleAlpha.toFloat() / 100
-        subtitle?.alpha = styleSheet.subtitleAlpha.toFloat() / 100
-        title?.gravity = styleSheet.titleGravity
-        
-        // 设置文本大小适应小空间
-        if (total > 2) {
-            title?.textSize = 10f
-            subtitle?.textSize = 8f
-        }
-        
-        return childView
-    }
-
-    interface OnDuplicateCardLongClickListener {
-        fun onDuplicateLongClick(v: View, list: List<EventItem>): Boolean
-    }
-
-
-    @Suppress("UNCHECKED_CAST")
     fun getDow(): Int {
-        if (block is EventItem) {
-            return (block as EventItem).getDow()
-        } else if (block is List<*>) {
-            return (block as List<EventItem>)[0].getDow()
-        }
-        return -1
+        return event.getDow()
     }
 
-    @Suppress("UNCHECKED_CAST")
     fun getDuration(): Int {
-        if (block is EventItem) {
-            return (block as EventItem).getDurationInMinutes()
-        } else if (block is List<*>) {
-            // 对于冲突课程，返回第一个课程的时间段（因为它们是并行的）
-            val list = block as List<EventItem>
-            return list[0].getDurationInMinutes()
-        }
-        return -1
+        return event.getDurationInMinutes()
     }
 
     fun getStartTime(): Long {
-        if (block is EventItem) {
-            return (block as EventItem).from.time
-        } else if (block is List<*>) {
-            var minStart = Long.MAX_VALUE
-            for (e in block as List<*>) {
-                minStart = min(minStart, (e as EventItem).from.time)
-            }
-            return minStart
-        }
-        return -1
+        return event.from.time
     }
 
+    fun getColumnIndex(): Int {
+        return columnIndex
+    }
 
+    fun getColumnCount(): Int {
+        return columnCount
+    }
 }

--- a/app/src/main/java/com/stupidtree/hitax/ui/main/timetable/views/TimeTableView.kt
+++ b/app/src/main/java/com/stupidtree/hitax/ui/main/timetable/views/TimeTableView.kt
@@ -2,7 +2,11 @@ package com.stupidtree.hitax.ui.main.timetable.views
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.graphics.*
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.DashPathEffect
+import android.graphics.Paint
+import android.graphics.Path
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -13,16 +17,15 @@ import com.stupidtree.hitax.data.model.timetable.TimeInDay
 import com.stupidtree.hitax.data.model.timetable.TimePeriodInDay
 import com.stupidtree.hitax.data.model.timetable.Timetable
 import com.stupidtree.hitax.ui.main.timetable.TimetableStyleSheet
-import com.stupidtree.hitax.ui.main.timetable.views.TimeTableBlockView.*
 import com.stupidtree.hitax.utils.TimeTools
-import java.util.*
+import java.util.Calendar
 import kotlin.math.max
-import kotlin.math.min
 
 class TimeTableView : ViewGroup {
-    companion object{
+    companion object {
         var timetableStructure = Timetable().scheduleStructure
     }
+
     var mWidth = 0
     var mHeight = 0
     var sectionWidth = 0
@@ -34,7 +37,6 @@ class TimeTableView : ViewGroup {
     private val startDate: Calendar = Calendar.getInstance()
     private var onCardClickListener: OnCardClickListener? = null
     private var onAddClickListener: OnAddClickListener? = null
-
     private var onCardLongClickListener: OnCardLongClickListener? = null
     private val mPathEffect = DashPathEffect(floatArrayOf(20f, 20f), 0f)
     private val mLinePaint = Paint()
@@ -51,6 +53,8 @@ class TimeTableView : ViewGroup {
         typedTimeTableView(attrs, defStyleAttr)
     }
 
+    constructor(context: Context?) : super(context)
+
     fun setOnCardClickListener(onCardClickListener: OnCardClickListener?) {
         this.onCardClickListener = onCardClickListener
     }
@@ -62,8 +66,6 @@ class TimeTableView : ViewGroup {
     fun setOnCardLongClickListener(onCardLongClickListener: OnCardLongClickListener?) {
         this.onCardLongClickListener = onCardLongClickListener
     }
-
-    constructor(context: Context?) : super(context) {}
 
     override fun dispatchDraw(canvas: Canvas) {
         if (TimeTools.isSameWeekWithStartDate(startDate, System.currentTimeMillis())) {
@@ -81,22 +83,22 @@ class TimeTableView : ViewGroup {
             0
         )
         val n = a.indexCount
-        for (i in 0..n) {
+        for (i in 0 until n) {
             when (val attr = a.getIndex(i)) {
-                R.styleable.TimeTableViewGroup_timeLineColor ->                     // 默认颜色设置为黑色
+                R.styleable.TimeTableViewGroup_timeLineColor ->
                     timelineColor = a.getColor(attr, Color.BLACK)
             }
         }
+        a.recycle()
     }
 
     private fun drawTodayRect(canvas: Canvas) {
-        val left: Int = sectionWidth * (TimeTools.currentDOW() - 1)
+        val left = sectionWidth * (TimeTools.currentDOW() - 1)
         val right = left + sectionWidth
         val paint = Paint()
         paint.color = styleSheet.todayBGColor
         canvas.drawRect(left.toFloat(), 0f, right.toFloat(), mHeight.toFloat(), paint)
     }
-
 
     private fun drawLabels(canvas: Canvas) {
         mLinePaint.style = Paint.Style.STROKE
@@ -107,7 +109,7 @@ class TimeTableView : ViewGroup {
         val temp = TimeInDay(0, 0)
         for (i in styleSheet.getStartTimeObject().hour..23) {
             temp.hour = i
-            val top = ((i - styleSheet.getStartTimeObject().hour) * sectionHeight)
+            val top = (i - styleSheet.getStartTimeObject().hour) * sectionHeight
             if (styleSheet.drawBGLine) {
                 val mLinePath = Path()
                 mLinePath.moveTo(0f, top.toFloat())
@@ -117,79 +119,18 @@ class TimeTableView : ViewGroup {
         }
     }
 
-
-    /**
-     * 更新视图
-     */
     fun notifyRefresh(startDate: Long, events: List<EventItem>, styleSheet: TimetableStyleSheet) {
         this.styleSheet = styleSheet
         this.startDate.timeInMillis = startDate
         removeAllViewsInLayout()
         requestLayout()
-        for (evs in aggregateEvents(events)) {
-            addBlock(evs)
+        for (positionedEvent in TimetableOverlapLayout.arrange(events)) {
+            addBlock(positionedEvent)
         }
-        //将同组的聚合
         invalidate()
         sectionHeight = this.styleSheet.cardHeight
     }
 
-
-    class Interval(e: EventItem) {
-        var from: Long = 0
-        var to: Long = 1
-        var evs: MutableList<EventItem> = mutableListOf()
-
-        init {
-            from = e.from.time
-            to = e.to.time
-            evs.add(e)
-        }
-        fun getDuration():Long{
-            return to-from
-        }
-        fun add(e: EventItem) {
-            from = min(from, e.from.time)
-            to = max(to, e.to.time)
-            evs.add(e)
-        }
-    }
-
-    private fun aggregateEvents(events: List<EventItem>): List<List<EventItem>> {
-        val res = mutableListOf<List<EventItem>>()
-        val buk = arrayOfNulls<MutableList<EventItem>>(7)
-        for (i in 0 until 7) buk[i] = mutableListOf()
-        //按照周数映射
-        for (event in events) {
-            buk[event.getDow() - 1]?.add(event)
-        }
-        for (dow in 0 until 7) {
-            val b = buk[dow] ?: mutableListOf()
-            if (b.isEmpty()) continue
-            b.sortWith { i1, i2 -> i1.from.compareTo(i2.from) }
-            val lst: LinkedList<Interval> = LinkedList()
-            for (e in b) {
-                if (lst.isEmpty() || lst.peekLast()!!.to < e.from.time
-                    ||( lst.peekLast()!!.to - e.from.time < e.getDurationInMills() * 0.5
-                            && lst.peekLast()!!.to - e.from.time < lst.peekLast()!!.getDuration()*0.5)
-
-                ) { //不重叠(或遮盖少于一半)，加入队列
-                    val itm = Interval(e)
-                    lst.offerLast(itm)
-                } else { //重叠且覆盖>50%
-                    lst.peekLast()!!.add(e)
-                }
-            }
-            for (inter in lst) {
-                res.add(inter.evs)
-            }
-        }
-        return res
-    }
-
-    /**
-     * 仅更新startDate
-     */
     fun setStartDate(ts: Long) {
         startDate.timeInMillis = ts
         invalidate()
@@ -223,10 +164,8 @@ class TimeTableView : ViewGroup {
             if (period != null) {
                 if (period.from.before(st)) period.from = st.getAdded(0)
                 addButton = TimeTableBlockAddView(context, period, dow)
-
                 addView(addButton)
                 addButton?.onAddClickListener = object : TimeTableBlockAddView.OnAddClickListener {
-
                     override fun onClick(view: View) {
                         onAddClickListener?.onAddClick(dow, period)
                     }
@@ -241,7 +180,7 @@ class TimeTableView : ViewGroup {
     @SuppressLint("DrawAllocation")
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        val totalMinutes: Int =
+        val totalMinutes =
             (endTime.hour - styleSheet.startTime / 100) * 60 + endTime.minute - styleSheet.startTime % 100
         setMeasuredDimension(
             MeasureSpec.getSize(widthMeasureSpec),
@@ -255,13 +194,12 @@ class TimeTableView : ViewGroup {
             (totalMinutes.toFloat() / 60f * sectionHeight).toInt(),
             MeasureSpec.EXACTLY
         )
-        sectionWidth = (mWidth) / 7
+        sectionWidth = mWidth / 7
         for (i in 0 until childCount) {
             when (val child = getChildAt(i)) {
                 is TimeTableBlockView -> {
-                    val cw = MeasureSpec.makeMeasureSpec(sectionWidth, MeasureSpec.EXACTLY)
-                    val cH: Int =
-                        MeasureSpec.makeMeasureSpec(getCardHeight(child), MeasureSpec.EXACTLY)
+                    val cw = MeasureSpec.makeMeasureSpec(getCardWidth(child), MeasureSpec.EXACTLY)
+                    val cH = MeasureSpec.makeMeasureSpec(getCardHeight(child), MeasureSpec.EXACTLY)
                     child.measure(cw, cH)
                 }
                 is TimeTableNowLine -> {
@@ -277,39 +215,29 @@ class TimeTableView : ViewGroup {
                     )
                     child.measure(cw, cH)
                 }
-                else -> {
-                    measureChild(child, widthMeasureSpec, heightMeasureSpec)
-                }
+                else -> measureChild(child, widthMeasureSpec, heightMeasureSpec)
             }
-
-            //
         }
     }
 
     fun init() {
         this.styleSheet = TimetableStyleSheet()
         sectionHeight = styleSheet.cardHeight
-        isClickable = true //设置为可点击，否则onTouchEvent只返回DOWN
+        isClickable = true
     }
 
     override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-        val count = childCount //获得子控件个数
-
-        for (i in 0 until count) {
+        for (i in 0 until childCount) {
             when (val child = getChildAt(i)) {
                 is TimeTableBlockView -> {
                     val lastTime = child.getDuration().toFloat()
-                    val startTimeFromBeginning: Int =
-                        styleSheet.getStartTimeObject()
-                            .getDistanceInMinutes(child.getStartTime())
-                    //计算左边的坐标
-                    val left = sectionWidth * (child.getDow() - 1)
-                    //计算右边坐标
-                    val right = left + sectionWidth
-                    //计算顶部坐标
+                    val startTimeFromBeginning =
+                        styleSheet.getStartTimeObject().getDistanceInMinutes(child.getStartTime())
+                    val dayLeft = sectionWidth * (child.getDow() - 1)
+                    val left = dayLeft + getColumnLeft(child)
+                    val right = dayLeft + getColumnRight(child)
                     val top = (startTimeFromBeginning / 60f * sectionHeight).toInt()
                     val bottom = top + (lastTime / 60f * sectionHeight).toInt()
-                    // block.measure(sectionWidth,getCardHeight(block));
                     child.layout(left, top, right, bottom)
                 }
                 is TimeTableNowLine -> {
@@ -320,55 +248,39 @@ class TimeTableView : ViewGroup {
                     child.layout(0, top, mWidth, top + 4)
                 }
                 is TimeTableBlockAddView -> {
-                    val left: Int = sectionWidth * (child.dow - 1)
+                    val left = sectionWidth * (child.dow - 1)
                     val right = left + sectionWidth
-                    val startTimeFromBeginning: Int = styleSheet.getStartTimeObject()
-                        .getDistanceInMinutes(child.timePeriod.from)
+                    val startTimeFromBeginning =
+                        styleSheet.getStartTimeObject().getDistanceInMinutes(child.timePeriod.from)
                     val top = (startTimeFromBeginning / 60f * sectionHeight).toInt()
                     val bottom = top + (child.duration / 60f * sectionHeight).toInt()
-                    //Log.e("pos",top+","+bottom+","+left+","+right);
                     child.layout(left, top, right, bottom)
                 }
             }
-
-
-            // Log.e("mes:",top+","+bottom+","+left+","+right);
         }
     }
 
-    private fun addBlock(o: List<EventItem>) {
-        if (o.size <= 1) {
-            val timeTableBlockView = TimeTableBlockView(context, o[0], styleSheet)
-            timeTableBlockView.onCardClickListener =
-                object : TimeTableBlockView.OnCardClickListener {
-                    override fun onClick(v: View, ei: EventItem) {
-                        onCardClickListener?.onEventClick(v, ei)
-                    }
+    private fun addBlock(positionedEvent: TimetableOverlapLayout.PositionedEvent) {
+        val timeTableBlockView = TimeTableBlockView(
+            context,
+            positionedEvent.event,
+            styleSheet,
+            positionedEvent.columnIndex,
+            positionedEvent.columnCount
+        )
+        timeTableBlockView.onCardClickListener =
+            object : TimeTableBlockView.OnCardClickListener {
+                override fun onClick(v: View, ei: EventItem) {
+                    onCardClickListener?.onEventClick(v, ei)
                 }
-
-            timeTableBlockView.onCardLongClickListener =
-                object : TimeTableBlockView.OnCardLongClickListener {
-                    override fun onLongClick(v: View, ei: EventItem): Boolean {
-                        return onCardLongClickListener?.onEventLongClick(v, ei) == true
-                    }
+            }
+        timeTableBlockView.onCardLongClickListener =
+            object : TimeTableBlockView.OnCardLongClickListener {
+                override fun onLongClick(v: View, ei: EventItem): Boolean {
+                    return onCardLongClickListener?.onEventLongClick(v, ei) == true
                 }
-            addView(timeTableBlockView)
-        } else {
-            val timeTableBlockView = TimeTableBlockView(context, o, styleSheet)
-            timeTableBlockView.onDuplicateCardClickListener =
-                object : OnDuplicateCardClickListener {
-                    override fun onDuplicateClick(v: View, list: List<EventItem>) {
-                        onCardClickListener?.onDuplicateEventClick(v, list)
-                    }
-                }
-            timeTableBlockView.onDuplicateCardLongClickListener =
-                object : OnDuplicateCardLongClickListener {
-                    override fun onDuplicateLongClick(v: View, list: List<EventItem>): Boolean {
-                        return onCardLongClickListener?.onDuplicateEventClick(v, list) == true
-                    }
-                }
-            addView(timeTableBlockView)
-        }
+            }
+        addView(timeTableBlockView)
     }
 
     interface OnCardClickListener {
@@ -378,6 +290,24 @@ class TimeTableView : ViewGroup {
 
     private fun getCardHeight(timeTableBlockView: TimeTableBlockView): Int {
         return (timeTableBlockView.getDuration() / 60f * sectionHeight).toInt()
+    }
+
+    private fun getCardWidth(timeTableBlockView: TimeTableBlockView): Int {
+        return max(1, getColumnRight(timeTableBlockView) - getColumnLeft(timeTableBlockView))
+    }
+
+    private fun getColumnLeft(timeTableBlockView: TimeTableBlockView): Int {
+        return timeTableBlockView.getColumnIndex() * sectionWidth / max(
+            1,
+            timeTableBlockView.getColumnCount()
+        )
+    }
+
+    private fun getColumnRight(timeTableBlockView: TimeTableBlockView): Int {
+        return (timeTableBlockView.getColumnIndex() + 1) * sectionWidth / max(
+            1,
+            timeTableBlockView.getColumnCount()
+        )
     }
 
     interface OnCardLongClickListener {

--- a/app/src/main/java/com/stupidtree/hitax/ui/main/timetable/views/TimetableCardTextScale.kt
+++ b/app/src/main/java/com/stupidtree/hitax/ui/main/timetable/views/TimetableCardTextScale.kt
@@ -1,0 +1,11 @@
+package com.stupidtree.hitax.ui.main.timetable.views
+
+object TimetableCardTextScale {
+    fun forColumnCount(columnCount: Int): Float {
+        return if (columnCount > 1) 0.5f else 1f
+    }
+
+    fun marginScaleForColumnCount(columnCount: Int): Float {
+        return if (columnCount > 1) 0.5f else 1f
+    }
+}

--- a/app/src/main/java/com/stupidtree/hitax/ui/main/timetable/views/TimetableOverlapLayout.kt
+++ b/app/src/main/java/com/stupidtree/hitax/ui/main/timetable/views/TimetableOverlapLayout.kt
@@ -1,0 +1,79 @@
+package com.stupidtree.hitax.ui.main.timetable.views
+
+import com.stupidtree.hitax.data.model.timetable.EventItem
+import kotlin.math.max
+
+object TimetableOverlapLayout {
+    data class PositionedEvent(
+        val event: EventItem,
+        val columnIndex: Int,
+        val columnCount: Int
+    )
+
+    private data class Cluster(
+        val events: MutableList<EventItem> = mutableListOf(),
+        var endTime: Long = Long.MIN_VALUE
+    )
+
+    private data class ActiveColumn(
+        val columnIndex: Int,
+        val endTime: Long
+    )
+
+    fun arrange(events: List<EventItem>): List<PositionedEvent> {
+        if (events.isEmpty()) {
+            return emptyList()
+        }
+        val positioned = mutableListOf<PositionedEvent>()
+        events.groupBy { it.getDow() }
+            .toSortedMap()
+            .values
+            .forEach { dayEvents ->
+                val sortedEvents = dayEvents.sortedWith(
+                    compareBy<EventItem>({ it.from.time }, { it.to.time }, { it.id })
+                )
+                splitIntoClusters(sortedEvents).forEach { cluster ->
+                    positioned.addAll(positionCluster(cluster.events))
+                }
+            }
+        return positioned
+    }
+
+    private fun splitIntoClusters(events: List<EventItem>): List<Cluster> {
+        if (events.isEmpty()) {
+            return emptyList()
+        }
+        val clusters = mutableListOf<Cluster>()
+        var current: Cluster? = null
+        for (event in events) {
+            if (current == null || event.from.time >= current.endTime) {
+                current = Cluster()
+                clusters.add(current)
+            }
+            current.events.add(event)
+            current.endTime = max(current.endTime, event.to.time)
+        }
+        return clusters
+    }
+
+    private fun positionCluster(events: List<EventItem>): List<PositionedEvent> {
+        val positioned = mutableListOf<PositionedEvent>()
+        val activeColumns = mutableListOf<ActiveColumn>()
+        var maxColumns = 1
+
+        for (event in events) {
+            activeColumns.removeAll { it.endTime <= event.from.time }
+            val usedColumns = activeColumns.map { it.columnIndex }.toSet()
+            var columnIndex = 0
+            while (usedColumns.contains(columnIndex)) {
+                columnIndex++
+            }
+            activeColumns.add(ActiveColumn(columnIndex, event.to.time))
+            activeColumns.sortBy { it.columnIndex }
+            maxColumns = max(maxColumns, activeColumns.size)
+            positioned.add(PositionedEvent(event, columnIndex, 1))
+        }
+
+        return positioned.map { it.copy(columnCount = maxColumns) }
+    }
+}

--- a/app/src/test/java/com/stupidtree/hitax/data/repository/IcsImportEventMapperTest.kt
+++ b/app/src/test/java/com/stupidtree/hitax/data/repository/IcsImportEventMapperTest.kt
@@ -1,0 +1,34 @@
+package com.stupidtree.hitax.data.repository
+
+import com.stupidtree.hitax.data.model.timetable.EventItem
+import net.fortuna.ical4j.model.DateTime
+import net.fortuna.ical4j.model.component.VEvent
+import net.fortuna.ical4j.model.property.Location
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.sql.Timestamp
+
+class IcsImportEventMapperTest {
+    @Test
+    fun map_preservesExactTimesAndClearsPeriodMetadata() {
+        val start = DateTime("20260407T131000")
+        val end = DateTime("20260407T144000")
+        val event = VEvent(start, end, "线性代数")
+        event.properties.add(Location("正心12 李老师"))
+
+        val mapped = IcsImportEventMapper.map(event, "tt-1")
+
+        assertNotNull(mapped)
+        mapped ?: return
+        assertEquals("tt-1", mapped.timetableId)
+        assertEquals("线性代数", mapped.name)
+        assertEquals("正心12", mapped.place)
+        assertEquals("李老师", mapped.teacher)
+        assertEquals(Timestamp(start.time), mapped.from)
+        assertEquals(Timestamp(end.time), mapped.to)
+        assertEquals(EventItem.TYPE.OTHER, mapped.type)
+        assertEquals(0, mapped.fromNumber)
+        assertEquals(0, mapped.lastNumber)
+    }
+}

--- a/app/src/test/java/com/stupidtree/hitax/ui/main/timetable/views/TimetableCardTextScaleTest.kt
+++ b/app/src/test/java/com/stupidtree/hitax/ui/main/timetable/views/TimetableCardTextScaleTest.kt
@@ -1,0 +1,24 @@
+package com.stupidtree.hitax.ui.main.timetable.views
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TimetableCardTextScaleTest {
+    @Test
+    fun textScale_keepsFullSizeForSingleColumn() {
+        assertEquals(1f, TimetableCardTextScale.forColumnCount(1), 0f)
+    }
+
+    @Test
+    fun textScale_halvesTextForSideBySideCards() {
+        assertEquals(0.5f, TimetableCardTextScale.forColumnCount(2), 0f)
+        assertEquals(0.5f, TimetableCardTextScale.forColumnCount(3), 0f)
+    }
+
+    @Test
+    fun marginScale_halvesSpacingForSideBySideCards() {
+        assertEquals(1f, TimetableCardTextScale.marginScaleForColumnCount(1), 0f)
+        assertEquals(0.5f, TimetableCardTextScale.marginScaleForColumnCount(2), 0f)
+        assertEquals(0.5f, TimetableCardTextScale.marginScaleForColumnCount(3), 0f)
+    }
+}

--- a/app/src/test/java/com/stupidtree/hitax/ui/main/timetable/views/TimetableOverlapLayoutTest.kt
+++ b/app/src/test/java/com/stupidtree/hitax/ui/main/timetable/views/TimetableOverlapLayoutTest.kt
@@ -1,0 +1,74 @@
+package com.stupidtree.hitax.ui.main.timetable.views
+
+import com.stupidtree.hitax.data.model.timetable.EventItem
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.sql.Timestamp
+import java.util.Calendar
+
+class TimetableOverlapLayoutTest {
+    @Test
+    fun arrange_keepsFullWidthForNonOverlappingEvents() {
+        val first = event("first", day = 0, startHour = 9, startMinute = 0, endHour = 10, endMinute = 0)
+        val second = event("second", day = 0, startHour = 10, startMinute = 0, endHour = 11, endMinute = 0)
+
+        val arranged = TimetableOverlapLayout.arrange(listOf(first, second)).associateBy { it.event.id }
+
+        assertEquals(1, arranged.getValue(first.id).columnCount)
+        assertEquals(0, arranged.getValue(first.id).columnIndex)
+        assertEquals(1, arranged.getValue(second.id).columnCount)
+        assertEquals(0, arranged.getValue(second.id).columnIndex)
+    }
+
+    @Test
+    fun arrange_splitsOverlappingEventsIntoColumns() {
+        val first = event("first", day = 0, startHour = 9, startMinute = 0, endHour = 10, endMinute = 0)
+        val second = event("second", day = 0, startHour = 9, startMinute = 30, endHour = 10, endMinute = 30)
+
+        val arranged = TimetableOverlapLayout.arrange(listOf(first, second)).associateBy { it.event.id }
+
+        assertEquals(2, arranged.getValue(first.id).columnCount)
+        assertEquals(2, arranged.getValue(second.id).columnCount)
+        assertEquals(0, arranged.getValue(first.id).columnIndex)
+        assertEquals(1, arranged.getValue(second.id).columnIndex)
+    }
+
+    @Test
+    fun arrange_keepsClusterWidthAtPeakConcurrencyForOverlapChain() {
+        val first = event("first", day = 0, startHour = 9, startMinute = 0, endHour = 10, endMinute = 0)
+        val second = event("second", day = 0, startHour = 9, startMinute = 30, endHour = 10, endMinute = 30)
+        val third = event("third", day = 0, startHour = 10, startMinute = 0, endHour = 11, endMinute = 0)
+
+        val arranged = TimetableOverlapLayout.arrange(listOf(first, second, third)).associateBy { it.event.id }
+
+        assertEquals(2, arranged.getValue(first.id).columnCount)
+        assertEquals(2, arranged.getValue(second.id).columnCount)
+        assertEquals(2, arranged.getValue(third.id).columnCount)
+        assertEquals(0, arranged.getValue(first.id).columnIndex)
+        assertEquals(1, arranged.getValue(second.id).columnIndex)
+        assertEquals(0, arranged.getValue(third.id).columnIndex)
+    }
+
+    private fun event(
+        id: String,
+        day: Int,
+        startHour: Int,
+        startMinute: Int,
+        endHour: Int,
+        endMinute: Int
+    ): EventItem {
+        val event = EventItem()
+        event.id = id
+        event.from = timestamp(day, startHour, startMinute)
+        event.to = timestamp(day, endHour, endMinute)
+        return event
+    }
+
+    private fun timestamp(day: Int, hour: Int, minute: Int): Timestamp {
+        val calendar = Calendar.getInstance().apply {
+            set(2026, Calendar.APRIL, 6 + day, hour, minute, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        return Timestamp(calendar.timeInMillis)
+    }
+}


### PR DESCRIPTION
## What changed
- render overlapping timetable events side by side with column reuse for non-overlapping follow-up blocks in the same cluster
- shrink text and inner spacing for split cards so parallel events remain readable
- stop ICS imports from inventing class-period metadata for non-standard event times and cover the mapper with tests

## Why
The old overlap handling stacked conflicts vertically inside one block, which made dense schedules hard to read. Imported ICS events also kept fake period numbers derived from a hardcoded schedule, so non-standard times could display misleading lesson ranges.

## Impact
- overlapping events now behave more like a calendar layout while keeping absolute-time placement
- touching events such as `10:00-12:00` and `12:00-13:00` can reuse the same column
- split cards use smaller text and tighter margins when multiple columns are active
- imported ICS events keep exact timestamps without showing fabricated class periods

## Validation
- `GRADLE_USER_HOME=/tmp/gradle-hita JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home PATH=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home/bin:$PATH ./gradlew -Dkotlin.compiler.execution.strategy=in-process :app:testDebugUnitTest --tests com.stupidtree.hitax.ui.main.timetable.views.TimetableCardTextScaleTest --tests com.stupidtree.hitax.ui.main.timetable.views.TimetableOverlapLayoutTest --tests com.stupidtree.hitax.data.repository.IcsImportEventMapperTest`
